### PR TITLE
Fix markdown format

### DIFF
--- a/chicago_taxi/README.md
+++ b/chicago_taxi/README.md
@@ -2,7 +2,7 @@
 
 Example to load [Chicago's taxi dataset](http://digital.cityofchicago.org/index.php/chicago-taxi-data-released/) in an EXASOL database.
 
-##Instructions
+## Instructions
 
 ### Prerequisites: 
 - EXASOL database, that is allowed to connect to the Internet and that has access to a nameserver


### PR DESCRIPTION
A space is expected between the ## and the headline.

To be fair, this is not written down in the [Github markdown guidlines](https://help.github.com/articles/basic-writing-and-formatting-syntax/#headings), which seem to be based on examples only.